### PR TITLE
feat: add luasnip, cmp_luasnip, and autotag support for enhanced editing

### DIFF
--- a/lazy-lock.json
+++ b/lazy-lock.json
@@ -1,10 +1,13 @@
 {
+  "LuaSnip": { "branch": "master", "commit": "de10d8414235b0a8cabfeba60d07c24304e71f5c" },
   "catppuccin": { "branch": "main", "commit": "30fa4d122d9b22ad8b2e0ab1b533c8c26c4dde86" },
   "cmp-buffer": { "branch": "main", "commit": "b74fab3656eea9de20a9b8116afa3cfc4ec09657" },
   "cmp-nvim-lsp": { "branch": "main", "commit": "bd5a7d6db125d4654b50eeae9f5217f24bb22fd3" },
   "cmp-nvim-lua": { "branch": "main", "commit": "f12408bdb54c39c23e67cab726264c10db33ada8" },
   "cmp-path": { "branch": "main", "commit": "c642487086dbd9a93160e1679a1327be111cbc25" },
+  "cmp_luasnip": { "branch": "master", "commit": "98d9cb5c2c38532bd9bdb481067b20fea8f32e90" },
   "conform.nvim": { "branch": "master", "commit": "b4aab989db276993ea5dcb78872be494ce546521" },
+  "friendly-snippets": { "branch": "main", "commit": "572f5660cf05f8cd8834e096d7b4c921ba18e175" },
   "gitsigns.nvim": { "branch": "main", "commit": "6e3c66548035e50db7bd8e360a29aec6620c3641" },
   "lazy.nvim": { "branch": "main", "commit": "6c3bda4aca61a13a9c63f1c1d1b16b9d3be90d7a" },
   "lspkind.nvim": { "branch": "master", "commit": "d79a1c3299ad0ef94e255d045bed9fa26025dab6" },
@@ -17,9 +20,10 @@
   "nui.nvim": { "branch": "main", "commit": "de740991c12411b663994b2860f1a4fd0937c130" },
   "nvim-autopairs": { "branch": "master", "commit": "23320e75953ac82e559c610bec5a90d9c6dfa743" },
   "nvim-cmp": { "branch": "main", "commit": "b5311ab3ed9c846b585c0c15b7559be131ec4be9" },
-  "nvim-lspconfig": { "branch": "master", "commit": "408cf07b97535825cca6f1afa908d98348712ba6" },
+  "nvim-lspconfig": { "branch": "master", "commit": "a3deebbd110016f50cc66b7b256120072f3804db" },
   "nvim-notify": { "branch": "master", "commit": "397c7c1184745fca649e5104de659e6392ef5a4d" },
   "nvim-treesitter": { "branch": "master", "commit": "42fc28ba918343ebfd5565147a42a26580579482" },
+  "nvim-ts-autotag": { "branch": "main", "commit": "a1d526af391f6aebb25a8795cbc05351ed3620b5" },
   "nvim-web-devicons": { "branch": "master", "commit": "f66cdfef5e84112045b9ebc3119fee9bddb3c687" },
   "oil-lsp-diagnostics.nvim": { "branch": "master", "commit": "e04e3c387262b958fee75382f8ff66eae9d037f4" },
   "oil.nvim": { "branch": "master", "commit": "07f80ad645895af849a597d1cac897059d89b686" },
@@ -27,5 +31,5 @@
   "snacks.nvim": { "branch": "main", "commit": "bc0630e43be5699bb94dadc302c0d21615421d93" },
   "toggleterm.nvim": { "branch": "main", "commit": "9a88eae817ef395952e08650b3283726786fb5fb" },
   "which-key.nvim": { "branch": "main", "commit": "370ec46f710e058c9c1646273e6b225acf47cbed" },
-  "yazi.nvim": { "branch": "main", "commit": "12409d3288683fa1836a022cc86431c1f0e3c093" }
+  "yazi.nvim": { "branch": "main", "commit": "6afc63a6f2996de06b77813c473fddd08a9edba3" }
 }

--- a/lua/configs/cmp.lua
+++ b/lua/configs/cmp.lua
@@ -1,5 +1,6 @@
 return function()
 	local cmp = require("cmp")
+	local luasnip = require("luasnip")
 	local cmp_autopairs = require("nvim-autopairs.completion.cmp")
 
 	local check_backspace = function()
@@ -22,6 +23,10 @@ return function()
 			["<Tab>"] = cmp.mapping(function(fallback)
 				if cmp.visible() then
 					cmp.select_next_item()
+				elseif luasnip.expandable() then
+					luasnip.expand()
+				elseif luasnip.expand_or_jumpable() then
+					luasnip.expand_or_jump()
 				elseif check_backspace() then
 					fallback()
 				else
@@ -31,6 +36,8 @@ return function()
 			["<S-Tab>"] = cmp.mapping(function(fallback)
 				if cmp.visible() then
 					cmp.select_prev_item()
+				elseif luasnip.jumpable(-1) then
+					luasnip.jump(-1)
 				else
 					fallback()
 				end
@@ -52,6 +59,7 @@ return function()
 		}),
 		sources = cmp.config.sources({
 			{ name = "nvim_lsp" },
+			{ name = "luasnip" },
 			{ name = "buffer" },
 			{ name = "path" },
 			{ name = "nvim_lua" },
@@ -69,6 +77,7 @@ return function()
 					buffer = "[Buffer]",
 					path = "[Path]",
 					nvim_lua = "[Lua]",
+					luasnip = "[Luasnip]",
 				})[entry.source.name] or ""
 
 				return kind

--- a/lua/configs/snacks.lua
+++ b/lua/configs/snacks.lua
@@ -20,7 +20,6 @@ return function()
 		indent = { enabled = true },
 		input = {
 			enabled = true,
-			size = 100,
 			mappings = {
 				["<Esc>"] = "close",
 			},
@@ -32,7 +31,7 @@ return function()
 		lazygit = { enabled = true },
 		styles = {
 			input = {
-				width = 100,
+				width = 80,
 			},
 		},
 	})

--- a/lua/options.lua
+++ b/lua/options.lua
@@ -12,8 +12,8 @@ vim.keymap.set("", "<LeftMouse>", "<Nop>")
 vim.keymap.set("", "<RightMouse>", "<Nop>")
 vim.cmd("set mousescroll=ver:1")
 vim.opt.scrolloff = 999
-utils.set_bg_transparent("NormalFloat")
-utils.set_bg_transparent("FloatBorder")
+-- utils.set_bg_transparent("NormalFloat")
+-- utils.set_bg_transparent("FloatBorder")
 
 vim.diagnostic.config({
 	signs = {

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -45,6 +45,7 @@ return {
 	{ "hrsh7th/cmp-path", event = "VeryLazy" },
 	{ "hrsh7th/cmp-nvim-lua", event = "VeryLazy" },
 	{ "onsails/lspkind.nvim", event = "VeryLazy" },
+	{ "saadparwaiz1/cmp_luasnip", event = "VeryLazy" },
 	{
 		"hrsh7th/nvim-cmp",
 		event = "InsertEnter",
@@ -62,11 +63,23 @@ return {
 		name = "catppuccin",
 		priority = 1000,
 		config = function()
+			require("catppuccin").setup({
+				background = {
+					light = "latte",
+					dark = "mocha",
+				},
+			})
+			vim.api.nvim_create_autocmd("ColorScheme", {
+				callback = function()
+					vim.api.nvim_set_hl(0, "WinSeparator", { link = "LineNr" })
+					vim.api.nvim_set_hl(0, "NeoTreeNormal", { bg = "None" })
+					vim.api.nvim_set_hl(0, "NeoTreeNormalNC", { bg = "None" })
+					vim.api.nvim_set_hl(0, "NeoTreeWinSeparator", { link = "WinSeparator" })
+					vim.api.nvim_set_hl(0, "NormalFloat", { link = "Normal" })
+					vim.api.nvim_set_hl(0, "FloatBorder", { link = "Title" })
+				end,
+			})
 			vim.cmd.colorscheme("catppuccin")
-			vim.api.nvim_set_hl(0, "WinSeparator", { link = "LineNr" })
-			vim.api.nvim_set_hl(0, "NeoTreeNormal", { bg = "none" })
-			vim.api.nvim_set_hl(0, "NeoTreeNormalNC", { bg = "none" })
-			vim.api.nvim_set_hl(0, "NeoTreeWinSeparator", { link = "WinSeparator" })
 		end,
 	},
 	{
@@ -116,6 +129,13 @@ return {
 					enable = true,
 				},
 			})
+		end,
+	},
+	{
+		"windwp/nvim-ts-autotag",
+		event = "InsertEnter",
+		config = function()
+			require("nvim-ts-autotag").setup()
 		end,
 	},
 	{
@@ -212,4 +232,39 @@ return {
 		},
 	},
 	{ "zapling/mason-conform.nvim" },
+	{
+		"L3MON4D3/LuaSnip",
+		opts = {
+			history = true,
+			delete_check_events = "TextChanged",
+		},
+		keys = {
+			{
+				"<tab>",
+				function()
+					require("luasnip").jump(1)
+				end,
+				mode = "s",
+			},
+			{
+				"<s-tab>",
+				function()
+					require("luasnip").jump(-1)
+				end,
+				mode = { "i", "s" },
+			},
+		},
+	},
+	{
+		"rafamadriz/friendly-snippets",
+		event = "InsertEnter",
+		config = function()
+			local luasnip = require("luasnip")
+			local loader = require("luasnip.loaders.from_vscode")
+
+			luasnip.filetype_extend("handlebars", { "html" })
+			loader.lazy_load()
+			loader.lazy_load({ paths = { vim.fn.stdpath("config") .. "/snippets" } })
+		end,
+	},
 }

--- a/lua/plugins/tools/conform.lua
+++ b/lua/plugins/tools/conform.lua
@@ -16,6 +16,7 @@ return {
 					sh = { "shfmt" },
 					markdown = { "prettier" },
 					dart = { "dart_format" },
+					handlebars = { "prettier" },
 				},
 				formatters = {
 					dart_format = {


### PR DESCRIPTION
- Integrated LuaSnip with nvim-cmp for snippet completion
- Added cmp_luasnip as a completion source
- Enabled snippet jumping with <Tab> and <S-Tab>
- Loaded friendly-snippets and custom snippets for luasnip
- Extended Handlebars snippets with HTML support
- Installed nvim-ts-autotag for automatic closing of HTML-like tags
- Enabled prettier formatting for handlebars via conform
- Refactored catppuccin color overrides into ColorScheme autocmd
- Adjusted input width in snacks config for better UI consistency
- Commented out transparent float background options in options.lua